### PR TITLE
Fix requiredFeatureCount struct assignment

### DIFF
--- a/src/device.jl
+++ b/src/device.jl
@@ -80,7 +80,7 @@ function requestDevice(
             WGPUDeviceDescriptor;
             label = toCString(label),
             nextInChain = convert(Ptr{WGPUChainedStruct}, deviceExtras |> ptr),
-            requiredFeaturesCount = 0,
+            requiredFeatureCount = 0,
             requiredLimits = (wgpuRequiredLimits |> ptr),
             defaultQueue = wgpuQueueDescriptor |> concrete,
         )


### PR DESCRIPTION
I noticed that there was a warning in the repl logs when running the triangle example about setting a non-existent struct field. I fixed it by replacing the assignment to requiredFeaturesCount with requiredFeatureCount, as is in the WebGPU header.

Thanks for your work on this!